### PR TITLE
ブックマーク数の桁がカンマで区切られても数を取得する

### DIFF
--- a/src/bookmark.py
+++ b/src/bookmark.py
@@ -13,7 +13,7 @@ class Bookmark:
         d = feedparser.parse('https://b.hatena.ne.jp/{}/rss'.format(self.hatena_id))
         content = d['feed']['subtitle'] # 'Userのはてなブックマーク (num)'
         match = re.search(r"(はてなブックマーク \()(.*?)\)", content)
-        num = match.group(2) # 公開しているブックマーク数
+        num = match.group(2).replace(',', '') # 公開しているブックマーク数
         if not num.isdecimal():
             print('Error: num is string', file=sys.stderr)
             return 0


### PR DESCRIPTION
1,000などになったとき、カンマが含まれているために、数ではなく、文字列として認識されてしまっていた。
カンマを取り除くようにした。